### PR TITLE
Make requirements.txt and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
-# chatbot
-chatbot test
+# ChatBot
+This is a TensorFlow-based chatbot that is trained off of the Cornell movie lines dataset.
+This program requires 64-bit Python to run as TensorFlow does not support 32-bit.
+The required third-party libraries can be installed with 'pip install -r requirements.txt'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+# A 64bit version of Python 3.6+ is required to run this program, as TensorFlow does not support 32bit.
+# Use 'pip install -r requirements.txt' to install the requirements
+pandas
+numpy
+tensorflow


### PR DESCRIPTION
All necessary third-party libraries can now be installed with `pip install -r requirements.txt`.  Should the need for another library arise, simply add the `pip` name to the text document in a new line, the pip name being the exact same name you used to install it using `pip`.